### PR TITLE
update to faraday 3

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_dependency 'builder', '~> 3.2'
-  spec.add_dependency 'faraday', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '< 2.0'
+  spec.add_dependency 'faraday', '< 3.0'
+  spec.add_dependency 'faraday_middleware', '< 3.0'
   spec.add_dependency 'json-jwt', '~> 1.7'
   spec.add_dependency 'simple_oauth', '~> 0.3.1'
   spec.add_dependency 'rexml'


### PR DESCRIPTION
will allow the usage of faraday 2+ with the ims-lti gem